### PR TITLE
Fix Gazebo launch arguments

### DIFF
--- a/docs/_03_aerial_platforms/_gazebo_simulation/index.rst
+++ b/docs/_03_aerial_platforms/_gazebo_simulation/index.rst
@@ -335,10 +335,10 @@ Example of launch command:
 
 .. code-block:: bash
 
-  ros2 launch as2_platform_gazebo platform_gazebo_launch.py namespace:=drone_sim_0 config_file:=world_json_path
+  ros2 launch as2_platform_gazebo platform_gazebo_launch.py namespace:=drone_sim_0 simulation_config_file:=world_json_path
 
 For launch the simulation, run the following command:
 
 .. code-block:: bash
 
-  ros2 launch as2_gazebo_assets launch_simulation.py config_file:=world_json_path
+  ros2 launch as2_gazebo_assets launch_simulation.py simulation_config_file:=world_json_path

--- a/docs/_03_aerial_platforms/_gazebo_simulation/index.rst
+++ b/docs/_03_aerial_platforms/_gazebo_simulation/index.rst
@@ -342,3 +342,6 @@ For launch the simulation, run the following command:
 .. code-block:: bash
 
   ros2 launch as2_gazebo_assets launch_simulation.py simulation_config_file:=world_json_path
+
+
+Additionally, for launching teleoperation and trying out a basic mission, continue to the [Gazebo Example Project](https://aerostack2.github.io/_02_examples/gazebo/project_gazebo/index.html)


### PR DESCRIPTION
This PR fixes launch arguments for `as2_platform_gazebo` as well as `as2_gazebo_assets` in the instructions for [Gazebo setup](https://aerostack2.github.io/_03_aerial_platforms/_gazebo_simulation/index.html#installation)

I've also linked the Gazebo Project Example at the end of the instructions to make it easier to find for anybody setting up GZ sim + AS2. 