### PR TITLE
Python formatter

### DIFF
--- a/docs/_09_development/_develop_guide/_develop_guide/_setting_code.rst
+++ b/docs/_09_development/_develop_guide/_develop_guide/_setting_code.rst
@@ -17,6 +17,8 @@ Install the following required extensions from the 'Extensions' tab in VSCode:
 * ``mine.cpplint``
 * ``ms-python.autopep8``
 * ``ms-python.pylint``
+* ``charliermarsh.ruff``
+* ``ms-python.isort``
 
 
 .. _development_guide_code_settings:

--- a/docs/_09_development/_develop_guide/_develop_guide/_setting_code.rst
+++ b/docs/_09_development/_develop_guide/_develop_guide/_setting_code.rst
@@ -74,6 +74,21 @@ Open your ``settings.json`` file from VSCode and add the following content to it
                     "--max-line-length=99", "--import-order-style=google", "--show-source=true",
                     "--statistics=true"],
 
+    "ruff.lineLength": 99,
+    "ruff.organizeImports": false,
+    "ruff.configuration" : {
+        "format" : {
+            "quote-style" : "single",
+            "line-ending" : "auto",
+        },
+    },
+    // isort to enforce propper import order
+    "isort.args": ["--line-length", "99", "--force-alphabetical-sort-within-sections", "--profile", "black", "--force-sort-within-sections"],
+    "pylint.args": ["--disable=B902,C816,D100,D101,D102,D103,D104,D105,D106,D107,D203,D212,D404,I202",
+                "--max-line-length=99", "--import-order-style=google", "--show-source=true",
+                "--statistics=true"
+    ]
+
 Newer versions of ROS 2 include upgraded flake8 (in ament_flake8), so it is preferable to use
 flake8 from VSCode too instead of pylint. To do so, use, instead of the 'pylint.args' settings,
 the following settings:


### PR DESCRIPTION
This PR adds vscode settings for ruff and isort to enable PEP8 and PEP256 compliant code formatting.